### PR TITLE
Allow setting the number of threads dynamically

### DIFF
--- a/src/chain/chain-tf.cc
+++ b/src/chain/chain-tf.cc
@@ -16,9 +16,13 @@ inline int64_t duration_in_mus(time_point const &t0, time_point const &t1) {
 
 std::atomic<int> task_counter = 0;
 
-int main(){
+int main(int argc, char *argv[]){
+  int nt = 1;
+  if (argc > 1) {
+    nt = std::atoi(argv[1]);
+  }
   
-  tf::Executor executor;
+  tf::Executor executor(nt);
   tf::Taskflow taskflow;
 
   auto t0 = now();

--- a/src/chain/chain-ttg.cc
+++ b/src/chain/chain-ttg.cc
@@ -68,7 +68,12 @@ auto make_ttg<false>() {
 
 int main(int argc, char* argv[]) {
 
-  ttg_initialize(argc, argv, -1);
+  int nt = 1;
+  if (argc > 1) {
+    nt = std::atoi(argv[1]);
+  }
+
+  ttg_initialize(argc, argv, nt);
 
   // change to true to flow task ids as values, this stresses the cost of managing data copies
   // default (false) uses task ids as usual (as "keys"), this avoids the need for data copy management

--- a/src/kdtree/kdtree-tf.cc
+++ b/src/kdtree/kdtree-tf.cc
@@ -32,9 +32,14 @@ struct NodeOp {
   }
 };
 
-int main(){
-  
-  tf::Executor executor;
+int main(int argc, char *argv[]){
+
+  int nt = std::thread::hardware_concurrency();
+  if (argc > 1) {
+    nt = std::atoi(argv[1]);
+  }
+
+  tf::Executor executor(nt);
   tf::Taskflow taskflow;
 
   auto t0 = now();

--- a/src/kdtree/kdtree-ttg.cc
+++ b/src/kdtree/kdtree-ttg.cc
@@ -38,7 +38,12 @@ auto make_ttg() {
 
 int main(int argc, char* argv[]) {
 
-  ttg_initialize(argc, argv, -1);
+  int nt = -1;
+  if (argc > 1) {
+    nt = std::atoi(argv[1]);
+  }
+
+  ttg_initialize(argc, argv, nt);
 
   // change to true to flow task ids as values, this stresses the cost of managing data copies
   // default (false) uses task ids as usual (as "keys"), this avoids the need for data copy management


### PR DESCRIPTION
Defaults:
- chain: 1 thread
- kdtree: runtime specific limit

Signed-off-by: Joseph Schuchart <schuchart@icl.utk.edu>